### PR TITLE
Fix CI GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         - Node.js 15.x
         - Node.js 16.x
         - Node.js 17.x
+        - Node.js 18.x
+        - Node.js 19.x
+        - Node.js 20.x
+        - Node.js 21.x
 
         include:
         - name: Node.js 0.8
@@ -106,6 +110,18 @@ jobs:
 
         - name: Node.js 17.x
           node-version: "17.4"
+
+        - name: Node.js 18.x
+          node-version: "18.20"
+
+        - name: Node.js 19.x
+          node-version: "19.9"
+
+        - name: Node.js 20.x
+          node-version: "20.12"
+
+        - name: Node.js 21.x
+          node-version: "21.7"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         name:
-        - Node.js 0.6
         - Node.js 0.8
         - Node.js 0.10
         - Node.js 0.12
@@ -33,11 +32,6 @@ jobs:
         - Node.js 17.x
 
         include:
-        - name: Node.js 0.6
-          node-version: "0.6"
-          npm-i: mocha@1.21.5
-          npm-rm: nyc
-
         - name: Node.js 0.8
           node-version: "0.8"
           npm-i: mocha@2.5.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         name:
@@ -73,19 +73,19 @@ jobs:
 
         - name: Node.js 6.x
           node-version: "6.17"
-          npm-i: mocha@6.2.2 nyc@14.1.1
+          npm-i: mocha@6.2.3 nyc@14.1.1
 
         - name: Node.js 7.x
           node-version: "7.10"
-          npm-i: mocha@6.2.2 nyc@14.1.1
+          npm-i: mocha@6.2.3 nyc@14.1.1
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 9.x
           node-version: "9.11"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 10.x
           node-version: "10.24"
@@ -108,7 +108,7 @@ jobs:
           node-version: "15.14"
 
         - name: Node.js 16.x
-          node-version: "16.14"
+          node-version: "16.13"
 
         - name: Node.js 17.x
           node-version: "17.4"
@@ -139,7 +139,15 @@ jobs:
         dirname "$(nvm which ${{ matrix.node-version }})" >> "$GITHUB_PATH"
 
     - name: Configure npm
-      run: npm config set shrinkwrap false
+      run: |
+        if [[ "$(npm config get package-lock)" == "true" ]]; then
+          npm config set package-lock false
+        else
+          npm config set shrinkwrap false
+        fi
+
+    - name: Remove non-test npm modules
+      run: npm rm --silent --save-dev csv-parse raw-body stream-to-array
 
     - name: Remove npm module(s) ${{ matrix.npm-rm }}
       run: npm rm --silent --save-dev ${{ matrix.npm-rm }}
@@ -190,7 +198,7 @@ jobs:
       uses: coverallsapp/github-action@master
       if: steps.list_env.outputs.nyc != ''
       with:
-        github-token: ${{ secrets.github_token }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         flag-name: run-${{ matrix.test_number }}
         parallel: true
 
@@ -201,5 +209,5 @@ jobs:
     - name: Upload code coverage
       uses: coverallsapp/github-action@master
       with:
-        github-token: ${{ secrets.github_token }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true


### PR DESCRIPTION
Work done

* [pin nyc versions for node 8 & 9 and fix npm config](https://github.com/jshttp/compressible/commit/9d340dbbe49258730002092e453b90d327280146)
* [remove node version 0.6 from ci gh action. It won't build on ubuntu 20](https://github.com/jshttp/compressible/commit/f1799d7bf0e8ab4cd3845f63655f76704c528b24)
* [add missing node versions to ci action](https://github.com/jshttp/compressible/commit/53c9da52004403f00b6702f57a6c6350bf4b087b)